### PR TITLE
Add structured error codes documentation (LIB-13469)

### DIFF
--- a/source/includes/_changelog.md
+++ b/source/includes/_changelog.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## January 2026
+
+### Booking Modification Restricted Attribute
+
+**New Feature** - The Booking object now includes a `modification-restricted` attribute that indicates whether a booking can be modified via partner APIs.
+
+When `restricted` is `true`, the booking requires manual intervention by restaurant staff through the Libro dashboard. The `reason` field provides a specific error code explaining why the booking cannot be modified programmatically.
+
+See the [Modification Restricted](#modification-restricted) section in the Booking documentation for details.
+
 ## October 2025
 
 ### Payment Intents API

--- a/source/includes/_changelog.md
+++ b/source/includes/_changelog.md
@@ -2,6 +2,25 @@
 
 ## January 2026
 
+### Structured Error Codes
+
+**New Feature** - API error responses now include structured error codes to help you programmatically handle errors.
+
+Error responses include three fields:
+
+- `code`: A unique error code (e.g., "2005")
+- `message`: A human-readable description
+- `error`: The legacy error key for backwards compatibility
+
+Error codes are grouped into ranges:
+
+- **1xxx**: Restaurant-level errors (authentication, configuration)
+- **2xxx**: Service/availability errors (slots, capacity)
+- **3xxx**: Booking data errors (validation)
+- **4xxx**: Operation errors (cancel, payment)
+
+See the [Error Codes](#error-codes) section for the complete list.
+
 ### Booking Modification Restricted Attribute
 
 **New Feature** - The Booking object now includes a `modification-restricted` attribute that indicates whether a booking can be modified via partner APIs.

--- a/source/includes/_errors.md
+++ b/source/includes/_errors.md
@@ -1,9 +1,8 @@
 # Common Errors
 
-The Libro API uses the following error codes:
+The Libro API uses the following HTTP status codes:
 
-
-Error Code | Meaning
+HTTP Code | Meaning
 ---------- | -------
 400 | Bad Request -- Your request is invalid.
 401 | Unauthorized -- The token is missing or invalid.
@@ -17,4 +16,67 @@ Error Code | Meaning
 429 | Too Many Requests -- You're requesting too many resources!
 500 | Internal Server Error -- We had a problem with our server. Try again later.
 
-`validation.offer.empty` indicates that the selected time slot requires payment through the ticketing system before a reservation can be completed.
+## Error Response Format
+
+> Example error response:
+
+```json
+{
+  "error": "validation.service.slots-unavailable-not-specific",
+  "code": "2005",
+  "message": "Party size is outside the allowed range for online booking. Please contact the restaurant directly."
+}
+```
+
+Error responses include the following fields:
+
+Field | Description
+----- | -----------
+error | A machine-readable error key for backwards compatibility
+code | A unique error code for programmatic error handling
+message | A human-readable description of the error
+
+## Error Codes
+
+The API uses structured error codes to help you programmatically handle errors. Error codes are grouped into ranges by category:
+
+### Restaurant-level Errors (1xxx)
+
+Code | Error Key | Description
+---- | --------- | -----------
+1001 | validation.restaurant.login-required | Customer login is required for this restaurant
+1002 | validation.restaurant.recaptcha-required | Recaptcha verification is required
+1003 | validation.restaurant.recaptcha-invalid | Invalid recaptcha response format
+1004 | validation.restaurant.recaptcha-failed | Recaptcha verification failed
+
+### Service/Availability Errors (2xxx)
+
+Code | Error Key | Description
+---- | --------- | -----------
+2001 | validation.service.slots-unavailable-not-specific | The requested time slot is not available
+2002 | validation.service.slots-unavailable-not-specific | The booking window for this time has closed
+2003 | validation.service.slots-unavailable-not-specific | Not enough availability for the requested party size
+2004 | validation.service.slots-unavailable-not-specific | Not enough availability at the requested time
+2005 | validation.service.slots-unavailable-not-specific | Party size is outside the allowed range for online booking
+2006 | exception.no-table | No suitable table is available for this reservation
+2007 | validation.service.date-out-of-range | The requested date is outside the booking window
+
+### Booking Data Errors (3xxx)
+
+Code | Error Key | Description
+---- | --------- | -----------
+3001 | validation.experience.unavailable | The selected experience is not available at this restaurant
+3002 | validation.classifications.invalid-restaurant | One or more classifications are not valid for this restaurant
+3003 | validation.booking.invalid | Booking validation failed
+3004 | validation.offer.empty | A prepaid offer selection is required for this reservation
+
+### Operation Errors (4xxx)
+
+Code | Error Key | Description
+---- | --------- | -----------
+4001 | validation.booking.not-cancelable | This booking cannot be canceled via the API
+4002 | validation.payment.failed | Payment processing failed
+
+<aside class="notice">
+The <code>error</code> field is provided for backwards compatibility. We recommend using the <code>code</code> field for programmatic error handling as it provides more specific information.
+</aside>

--- a/source/includes/_errors.md
+++ b/source/includes/_errors.md
@@ -48,6 +48,8 @@ Code | Error Key | Description
 1002 | validation.restaurant.recaptcha-required | Recaptcha verification is required
 1003 | validation.restaurant.recaptcha-invalid | Invalid recaptcha response format
 1004 | validation.restaurant.recaptcha-failed | Recaptcha verification failed
+1005 | You must select a restaurant | Restaurant selection is required
+1006 | You must select a date & time | Date and time selection is required
 
 ### Service/Availability Errors (2xxx)
 
@@ -60,12 +62,14 @@ Code | Error Key | Description
 2005 | validation.service.slots-unavailable-not-specific | Party size is outside the allowed range for online booking
 2006 | exception.no-table | No suitable table is available for this reservation
 2007 | validation.service.date-out-of-range | The requested date is outside the booking window
+2008 | service-not-found | The requested date and time is not available
 
 ### Booking Data Errors (3xxx)
 
 Code | Error Key | Description
 ---- | --------- | -----------
 3001 | validation.experience.unavailable | The selected experience is not available at this restaurant
+3001 | experience-not-found | The selected experience is not available at this restaurant
 3002 | validation.classifications.invalid-restaurant | One or more classifications are not valid for this restaurant
 3003 | validation.booking.invalid | Booking validation failed
 3004 | validation.offer.empty | A prepaid offer selection is required for this reservation
@@ -75,7 +79,6 @@ Code | Error Key | Description
 Code | Error Key | Description
 ---- | --------- | -----------
 4001 | validation.booking.not-cancelable | This booking cannot be canceled via the API
-4002 | validation.payment.failed | Payment processing failed
 
 <aside class="notice">
 The <code>error</code> field is provided for backwards compatibility. We recommend using the <code>code</code> field for programmatic error handling as it provides more specific information.

--- a/source/includes/bookings/_intro.md
+++ b/source/includes/bookings/_intro.md
@@ -46,7 +46,11 @@ The Bookings API allows you to create, retrieve, and manage reservations.
     },
     "invoice": null,
     "affiliate": null,
-    "cancelation-allowed-until": null
+    "cancelation-allowed-until": null,
+    "modification-restricted": {
+      "restricted": false,
+      "reason": null
+    }
   }
 }
 ```
@@ -67,6 +71,25 @@ The following flags are available:
 - `children`: indicates whether guests have signaled that their reservation includes children
 - `reduced-mobility`: indicates if the reservation requires accessibility accommodations
 - `do-not-move`: indicates that a Libro user has marked this reservation as immovable from its assigned table
+
+### Modification Restricted
+
+The `modification-restricted` attribute indicates whether a booking can be modified via partner APIs or if it requires manual intervention by restaurant staff through the Libro dashboard.
+
+```json
+{
+  "modification-restricted": {
+    "restricted": true,
+    "reason": "validation.service.party-size-exceeds-maximum"
+  }
+}
+```
+
+- `restricted` (boolean): When `true`, the booking cannot be modified via the API and requires restaurant staff to make changes manually.
+- `reason` (string|null): When restricted, contains an error code explaining why modification is not allowed. Common reasons include:
+  - `validation.service.party-size-exceeds-maximum`: The party size exceeds the maximum allowed for online bookings
+  - `validation.service.party-size-below-minimum`: The party size is below the minimum required
+  - `validation.service.date-out-of-range`: The booking date is beyond the allowed booking window
 
 ## Booking Relationships
 


### PR DESCRIPTION
## Summary

- Add error response format documentation with JSON example
- Document all structured error codes grouped by category
- Add changelog entry for the new feature
- Update error codes with newly added codes (1005, 1006, 2008, 3001 variant)
- Remove unused error code 4002 (payment_failed)

## Changes to _errors.md

- Updated header to "HTTP status codes" for clarity
- Added "Error Response Format" section with example JSON
- Added "Error Codes" section with tables for each category:
  - 1xxx: Restaurant-level errors (added 1005, 1006)
  - 2xxx: Service/availability errors (added 2008)
  - 3xxx: Booking data errors (added 3001 variant for experience_not_found)
  - 4xxx: Operation errors (removed 4002 payment_failed)

## New Error Codes Documented

- **1005** - `restaurant_required`: Restaurant selection is required
- **1006** - `date_time_required`: Date and time selection is required
- **2008** - `service_not_found`: The requested date and time is not available
- **3001** - `experience_not_found`: Second variant of code 3001 with different error key

## Related

- Core API PR: https://github.com/libroreserve/core-api/pull/1733

## Test plan

- [x] Verify documentation renders correctly
- [x] Error codes match implementation in ApiErrorCodes module
- [x] All new error codes (1005, 1006, 2008, 3001 variant) are documented
- [x] Unused error code 4002 has been removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)