### PR TITLE
LIB-15478/15697: Document async classifications + sync flow optional offer decline

### DIFF
--- a/build/index.html
+++ b/build/index.html
@@ -1046,7 +1046,7 @@ it includes additional details based on the type of payment.</p>
 
 <ol>
 <li><strong>Non-optional offers</strong> (with available tables) → Returns <code>TICKETING</code> payment type (overrides no-show policies)</li>
-<li><strong>Optional offers + no-show policy</strong> → Returns <code>NO_SHOW</code> payment type (policy takes precedence)</li>
+<li><strong>Optional offers + no-show policy</strong> → Returns <code>TICKETING</code> payment type (overrides no-show policies)</li>
 <li><strong>Optional offers + no policy</strong> → Returns <code>TICKETING</code> payment type</li>
 <li><strong>No offer + no-show policy</strong> → Returns <code>NO_SHOW</code> payment type</li>
 <li><strong>No offer + no policy</strong> → Returns <code>false</code></li>
@@ -1847,7 +1847,7 @@ Cancellation is only possible if the booking has not passed the cancellation dea
 <td style="text-align: left"><strong>TICKETING</strong></td>
 <td style="text-align: left">Capture payment for events/experience tickets</td>
 <td style="text-align: left">✓ Implemented</td>
-<td style="text-align: left">🚧 Work in Progress</td>
+<td style="text-align: left">✓ Implemented</td>
 </tr>
 </tbody></table>
 <h2 id='synchronous-flow'>Synchronous Flow</h2>
@@ -1910,7 +1910,7 @@ Cancellation is only possible if the booking has not passed the cancellation dea
         </span><span class="nl">"email"</span><span class="p">:</span><span class="w"> </span><span class="s2">"john.doe@example.com"</span><span class="p">,</span><span class="w">
         </span><span class="nl">"phone"</span><span class="p">:</span><span class="w"> </span><span class="s2">"+1234567890"</span><span class="p">,</span><span class="w">
         </span><span class="nl">"party_size"</span><span class="p">:</span><span class="w"> </span><span class="mi">4</span><span class="p">,</span><span class="w">
-        </span><span class="nl">"time"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2025-01-15T19:30:00Z"</span><span class="p">,</span><span class="w">
+        </span><span class="nl">"time"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2025-01-15T19:30:00"</span><span class="p">,</span><span class="w">
         </span><span class="nl">"locale"</span><span class="p">:</span><span class="w"> </span><span class="s2">"en"</span><span class="w">
       </span><span class="p">}</span><span class="w">
     </span><span class="p">}</span><span class="w">
@@ -1999,7 +1999,7 @@ Cancellation is only possible if the booking has not passed the cancellation dea
   </span><span class="nl">"restaurant-code"</span><span class="p">:</span><span class="w"> </span><span class="s2">"QC01621448XXXX"</span><span class="p">,</span><span class="w">
   </span><span class="nl">"data"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
     </span><span class="nl">"attributes"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
-      </span><span class="nl">"time"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2025-01-15T19:30:00Z"</span><span class="p">,</span><span class="w">
+      </span><span class="nl">"time"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2025-01-15T19:30:00"</span><span class="p">,</span><span class="w">
       </span><span class="nl">"party-size"</span><span class="p">:</span><span class="w"> </span><span class="mi">4</span><span class="p">,</span><span class="w">
       </span><span class="nl">"payment-intent-id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"0000000000"</span><span class="w">
       </span><span class="err">//</span><span class="w"> </span><span class="err">...</span><span class="w"> </span><span class="err">other</span><span class="w"> </span><span class="err">booking</span><span class="w"> </span><span class="err">attributes</span><span class="w">
@@ -2024,7 +2024,7 @@ Cancellation is only possible if the booking has not passed the cancellation dea
   </span><span class="nl">"restaurant-code"</span><span class="p">:</span><span class="w"> </span><span class="s2">"QC01621448XXXX"</span><span class="p">,</span><span class="w">
   </span><span class="nl">"data"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
     </span><span class="nl">"attributes"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
-      </span><span class="nl">"time"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2025-01-15T19:30:00Z"</span><span class="p">,</span><span class="w">
+      </span><span class="nl">"time"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2025-01-15T19:30:00"</span><span class="p">,</span><span class="w">
       </span><span class="nl">"party-size"</span><span class="p">:</span><span class="w"> </span><span class="mi">4</span><span class="w">
       </span><span class="err">//</span><span class="w"> </span><span class="err">...</span><span class="w"> </span><span class="err">other</span><span class="w"> </span><span class="err">booking</span><span class="w"> </span><span class="err">attributes</span><span class="w">
     </span><span class="p">}</span><span class="w">
@@ -2035,7 +2035,7 @@ Cancellation is only possible if the booking has not passed the cancellation dea
 
 <ul>
 <li><strong>For NO_SHOW:</strong> Link to complete no show authorization</li>
-<li><strong>For TICKETING:</strong> Link to select an offer and complete payment (Work In Progress)</li>
+<li><strong>For TICKETING:</strong> Link to select an offer and complete payment</li>
 </ul>
 <h4 id='step-3-guest-completes-payment'>Step 3: Guest Completes Payment</h4>
 <p>The guest clicks the link and completes the payment action:</p>
@@ -2113,7 +2113,7 @@ Cancellation is only possible if the booking has not passed the cancellation dea
       </span><span class="nl">"email"</span><span class="p">:</span><span class="w"> </span><span class="s2">"john.doe@example.com"</span><span class="p">,</span><span class="w">
       </span><span class="nl">"phone"</span><span class="p">:</span><span class="w"> </span><span class="s2">"+1234567890"</span><span class="p">,</span><span class="w">
       </span><span class="nl">"party_size"</span><span class="p">:</span><span class="w"> </span><span class="mi">4</span><span class="p">,</span><span class="w">
-      </span><span class="nl">"time"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2025-01-15T19:30:00Z"</span><span class="p">,</span><span class="w">
+      </span><span class="nl">"time"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2025-01-15T19:30:00"</span><span class="p">,</span><span class="w">
       </span><span class="nl">"locale"</span><span class="p">:</span><span class="w"> </span><span class="s2">"en"</span><span class="w">
     </span><span class="p">},</span><span class="w">
     </span><span class="nl">"created-at"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2025-01-10T12:00:00.000Z"</span><span class="w">
@@ -2190,7 +2190,7 @@ Cancellation is only possible if the booking has not passed the cancellation dea
         </span><span class="nl">"email"</span><span class="p">:</span><span class="w"> </span><span class="s2">"john.doe@example.com"</span><span class="p">,</span><span class="w">
         </span><span class="nl">"phone"</span><span class="p">:</span><span class="w"> </span><span class="s2">"+1234567890"</span><span class="p">,</span><span class="w">
         </span><span class="nl">"party_size"</span><span class="p">:</span><span class="w"> </span><span class="mi">4</span><span class="p">,</span><span class="w">
-        </span><span class="nl">"time"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2025-01-15T19:30:00Z"</span><span class="p">,</span><span class="w">
+        </span><span class="nl">"time"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2025-01-15T19:30:00"</span><span class="p">,</span><span class="w">
         </span><span class="nl">"locale"</span><span class="p">:</span><span class="w"> </span><span class="s2">"en"</span><span class="w">
       </span><span class="p">}</span><span class="w">
     </span><span class="p">}</span><span class="w">
@@ -2215,7 +2215,7 @@ Cancellation is only possible if the booking has not passed the cancellation dea
                 </span><span class="nl">"email"</span><span class="p">:</span><span class="w"> </span><span class="s2">"john.doe@example.com"</span><span class="p">,</span><span class="w">
                 </span><span class="nl">"phone"</span><span class="p">:</span><span class="w"> </span><span class="s2">"+1234567890"</span><span class="p">,</span><span class="w">
                 </span><span class="nl">"party_size"</span><span class="p">:</span><span class="w"> </span><span class="mi">4</span><span class="p">,</span><span class="w">
-                </span><span class="nl">"time"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2025-01-15T19:30:00Z"</span><span class="p">,</span><span class="w">
+                </span><span class="nl">"time"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2025-01-15T19:30:00"</span><span class="p">,</span><span class="w">
                 </span><span class="nl">"locale"</span><span class="p">:</span><span class="w"> </span><span class="s2">"en"</span><span class="w">
             </span><span class="p">},</span><span class="w">
             </span><span class="nl">"classifications"</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="w">
@@ -2318,7 +2318,7 @@ Cancellation is only possible if the booking has not passed the cancellation dea
 <td><code>time</code></td>
 <td>string</td>
 <td>Yes</td>
-<td>Booking datetime in ISO8601 format</td>
+<td>Booking datetime in ISO8601 format, in restaurant-local time and <strong>without</strong> a timezone marker (no <code>Z</code>, no offset). Same format we send back to you in the seatings response.</td>
 </tr>
 <tr>
 <td><code>locale</code></td>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1046,7 +1046,7 @@ it includes additional details based on the type of payment.</p>
 
 <ol>
 <li><strong>Non-optional offers</strong> (with available tables) → Returns <code>TICKETING</code> payment type (overrides no-show policies)</li>
-<li><strong>Optional offers + no-show policy</strong> → Returns <code>NO_SHOW</code> payment type (policy takes precedence)</li>
+<li><strong>Optional offers + no-show policy</strong> → Returns <code>TICKETING</code> payment type (overrides no-show policies)</li>
 <li><strong>Optional offers + no policy</strong> → Returns <code>TICKETING</code> payment type</li>
 <li><strong>No offer + no-show policy</strong> → Returns <code>NO_SHOW</code> payment type</li>
 <li><strong>No offer + no policy</strong> → Returns <code>false</code></li>
@@ -1847,7 +1847,7 @@ Cancellation is only possible if the booking has not passed the cancellation dea
 <td style="text-align: left"><strong>TICKETING</strong></td>
 <td style="text-align: left">Capture payment for events/experience tickets</td>
 <td style="text-align: left">✓ Implemented</td>
-<td style="text-align: left">🚧 Work in Progress</td>
+<td style="text-align: left">✓ Implemented</td>
 </tr>
 </tbody></table>
 <h2 id='synchronous-flow'>Synchronous Flow</h2>
@@ -1910,7 +1910,7 @@ Cancellation is only possible if the booking has not passed the cancellation dea
         </span><span class="nl">"email"</span><span class="p">:</span><span class="w"> </span><span class="s2">"john.doe@example.com"</span><span class="p">,</span><span class="w">
         </span><span class="nl">"phone"</span><span class="p">:</span><span class="w"> </span><span class="s2">"+1234567890"</span><span class="p">,</span><span class="w">
         </span><span class="nl">"party_size"</span><span class="p">:</span><span class="w"> </span><span class="mi">4</span><span class="p">,</span><span class="w">
-        </span><span class="nl">"time"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2025-01-15T19:30:00Z"</span><span class="p">,</span><span class="w">
+        </span><span class="nl">"time"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2025-01-15T19:30:00"</span><span class="p">,</span><span class="w">
         </span><span class="nl">"locale"</span><span class="p">:</span><span class="w"> </span><span class="s2">"en"</span><span class="w">
       </span><span class="p">}</span><span class="w">
     </span><span class="p">}</span><span class="w">
@@ -1999,7 +1999,7 @@ Cancellation is only possible if the booking has not passed the cancellation dea
   </span><span class="nl">"restaurant-code"</span><span class="p">:</span><span class="w"> </span><span class="s2">"QC01621448XXXX"</span><span class="p">,</span><span class="w">
   </span><span class="nl">"data"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
     </span><span class="nl">"attributes"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
-      </span><span class="nl">"time"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2025-01-15T19:30:00Z"</span><span class="p">,</span><span class="w">
+      </span><span class="nl">"time"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2025-01-15T19:30:00"</span><span class="p">,</span><span class="w">
       </span><span class="nl">"party-size"</span><span class="p">:</span><span class="w"> </span><span class="mi">4</span><span class="p">,</span><span class="w">
       </span><span class="nl">"payment-intent-id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"0000000000"</span><span class="w">
       </span><span class="err">//</span><span class="w"> </span><span class="err">...</span><span class="w"> </span><span class="err">other</span><span class="w"> </span><span class="err">booking</span><span class="w"> </span><span class="err">attributes</span><span class="w">
@@ -2024,7 +2024,7 @@ Cancellation is only possible if the booking has not passed the cancellation dea
   </span><span class="nl">"restaurant-code"</span><span class="p">:</span><span class="w"> </span><span class="s2">"QC01621448XXXX"</span><span class="p">,</span><span class="w">
   </span><span class="nl">"data"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
     </span><span class="nl">"attributes"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
-      </span><span class="nl">"time"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2025-01-15T19:30:00Z"</span><span class="p">,</span><span class="w">
+      </span><span class="nl">"time"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2025-01-15T19:30:00"</span><span class="p">,</span><span class="w">
       </span><span class="nl">"party-size"</span><span class="p">:</span><span class="w"> </span><span class="mi">4</span><span class="w">
       </span><span class="err">//</span><span class="w"> </span><span class="err">...</span><span class="w"> </span><span class="err">other</span><span class="w"> </span><span class="err">booking</span><span class="w"> </span><span class="err">attributes</span><span class="w">
     </span><span class="p">}</span><span class="w">
@@ -2035,7 +2035,7 @@ Cancellation is only possible if the booking has not passed the cancellation dea
 
 <ul>
 <li><strong>For NO_SHOW:</strong> Link to complete no show authorization</li>
-<li><strong>For TICKETING:</strong> Link to select an offer and complete payment (Work In Progress)</li>
+<li><strong>For TICKETING:</strong> Link to select an offer and complete payment</li>
 </ul>
 <h4 id='step-3-guest-completes-payment'>Step 3: Guest Completes Payment</h4>
 <p>The guest clicks the link and completes the payment action:</p>
@@ -2113,7 +2113,7 @@ Cancellation is only possible if the booking has not passed the cancellation dea
       </span><span class="nl">"email"</span><span class="p">:</span><span class="w"> </span><span class="s2">"john.doe@example.com"</span><span class="p">,</span><span class="w">
       </span><span class="nl">"phone"</span><span class="p">:</span><span class="w"> </span><span class="s2">"+1234567890"</span><span class="p">,</span><span class="w">
       </span><span class="nl">"party_size"</span><span class="p">:</span><span class="w"> </span><span class="mi">4</span><span class="p">,</span><span class="w">
-      </span><span class="nl">"time"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2025-01-15T19:30:00Z"</span><span class="p">,</span><span class="w">
+      </span><span class="nl">"time"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2025-01-15T19:30:00"</span><span class="p">,</span><span class="w">
       </span><span class="nl">"locale"</span><span class="p">:</span><span class="w"> </span><span class="s2">"en"</span><span class="w">
     </span><span class="p">},</span><span class="w">
     </span><span class="nl">"created-at"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2025-01-10T12:00:00.000Z"</span><span class="w">
@@ -2190,7 +2190,7 @@ Cancellation is only possible if the booking has not passed the cancellation dea
         </span><span class="nl">"email"</span><span class="p">:</span><span class="w"> </span><span class="s2">"john.doe@example.com"</span><span class="p">,</span><span class="w">
         </span><span class="nl">"phone"</span><span class="p">:</span><span class="w"> </span><span class="s2">"+1234567890"</span><span class="p">,</span><span class="w">
         </span><span class="nl">"party_size"</span><span class="p">:</span><span class="w"> </span><span class="mi">4</span><span class="p">,</span><span class="w">
-        </span><span class="nl">"time"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2025-01-15T19:30:00Z"</span><span class="p">,</span><span class="w">
+        </span><span class="nl">"time"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2025-01-15T19:30:00"</span><span class="p">,</span><span class="w">
         </span><span class="nl">"locale"</span><span class="p">:</span><span class="w"> </span><span class="s2">"en"</span><span class="w">
       </span><span class="p">}</span><span class="w">
     </span><span class="p">}</span><span class="w">
@@ -2215,7 +2215,7 @@ Cancellation is only possible if the booking has not passed the cancellation dea
                 </span><span class="nl">"email"</span><span class="p">:</span><span class="w"> </span><span class="s2">"john.doe@example.com"</span><span class="p">,</span><span class="w">
                 </span><span class="nl">"phone"</span><span class="p">:</span><span class="w"> </span><span class="s2">"+1234567890"</span><span class="p">,</span><span class="w">
                 </span><span class="nl">"party_size"</span><span class="p">:</span><span class="w"> </span><span class="mi">4</span><span class="p">,</span><span class="w">
-                </span><span class="nl">"time"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2025-01-15T19:30:00Z"</span><span class="p">,</span><span class="w">
+                </span><span class="nl">"time"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2025-01-15T19:30:00"</span><span class="p">,</span><span class="w">
                 </span><span class="nl">"locale"</span><span class="p">:</span><span class="w"> </span><span class="s2">"en"</span><span class="w">
             </span><span class="p">},</span><span class="w">
             </span><span class="nl">"classifications"</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="w">
@@ -2318,7 +2318,7 @@ Cancellation is only possible if the booking has not passed the cancellation dea
 <td><code>time</code></td>
 <td>string</td>
 <td>Yes</td>
-<td>Booking datetime in ISO8601 format</td>
+<td>Booking datetime in ISO8601 format, in restaurant-local time and <strong>without</strong> a timezone marker (no <code>Z</code>, no offset). Same format we send back to you in the seatings response.</td>
 </tr>
 <tr>
 <td><code>locale</code></td>

--- a/source/includes/payment_intents/_flows.md
+++ b/source/includes/payment_intents/_flows.md
@@ -93,7 +93,7 @@ Call `POST /restricted/payment-intents/initialize` with reservation and guest de
         "email": "john.doe@example.com",
         "phone": "+1234567890",
         "party_size": 4,
-        "time": "2025-01-15T19:30:00Z",
+        "time": "2025-01-15T19:30:00",
         "locale": "en"
       }
     }
@@ -203,7 +203,7 @@ Call the booking creation endpoint with the PaymentIntent ID:
   "restaurant-code": "QC01621448XXXX",
   "data": {
     "attributes": {
-      "time": "2025-01-15T19:30:00Z",
+      "time": "2025-01-15T19:30:00",
       "party-size": 4,
       "payment-intent-id": "0000000000"
       // ... other booking attributes
@@ -237,7 +237,7 @@ Call the booking creation endpoint with the reservation details.
   "restaurant-code": "QC01621448XXXX",
   "data": {
     "attributes": {
-      "time": "2025-01-15T19:30:00Z",
+      "time": "2025-01-15T19:30:00",
       "party-size": 4
       // ... other booking attributes
     }

--- a/source/includes/payment_intents/_flows.md
+++ b/source/includes/payment_intents/_flows.md
@@ -16,7 +16,7 @@ The choice between synchronous and asynchronous flows depends on your integratio
 | Payment Type | Purpose | Sync Flow | Async Flow |
 |:-------------|:--------|:----------|:-----------|
 | **NO_SHOW** | Authorize credit card to protect against no-shows | ✓ Implemented | ✓ Implemented |
-| **TICKETING** | Capture payment for events/experience tickets | ✓ Implemented | 🚧 Work in Progress |
+| **TICKETING** | Capture payment for events/experience tickets | ✓ Implemented | ✓ Implemented |
 
 ## Synchronous Flow
 
@@ -250,7 +250,7 @@ Call the booking creation endpoint with the reservation details.
 The guest automatically receives a link via SMS or email:
 
 - **For NO_SHOW:** Link to complete no show authorization
-- **For TICKETING:** Link to select an offer and complete payment (Work In Progress)
+- **For TICKETING:** Link to select an offer and complete payment
 
 #### Step 3: Guest Completes Payment
 

--- a/source/includes/payment_intents/_initialize.md
+++ b/source/includes/payment_intents/_initialize.md
@@ -32,7 +32,7 @@ curl "https://api.libroreserve.com/restricted/payment-intents/initialize" \
         "email": "john.doe@example.com",
         "phone": "+1234567890",
         "party_size": 4,
-        "time": "2025-01-15T19:30:00Z",
+        "time": "2025-01-15T19:30:00",
         "locale": "en"
       }
     }
@@ -58,7 +58,7 @@ curl "https://api.libroreserve.com/restricted/payment-intents/initialize" \
                 "email": "john.doe@example.com",
                 "phone": "+1234567890",
                 "party_size": 4,
-                "time": "2025-01-15T19:30:00Z",
+                "time": "2025-01-15T19:30:00",
                 "locale": "en"
             },
             "classifications": [
@@ -101,7 +101,7 @@ This endpoint allows you to initialize a payment intent for no-show policies or 
 | `email` | string | Yes | Guest's email address |
 | `phone` | string | Yes | Guest's phone number |
 | `party_size` | integer | Yes | Number of guests (must be greater than 0) |
-| `time` | string | Yes | Booking datetime in ISO8601 format |
+| `time` | string | Yes | Booking datetime in ISO8601 format, in restaurant-local time and **without** a timezone marker (no `Z`, no offset). Same format we send back to you in the seatings response. |
 | `locale` | string | Yes | Guest's locale (e.g., "en", "fr") |
 
 ### HTTP Status Codes

--- a/source/includes/payment_intents/_intro.md
+++ b/source/includes/payment_intents/_intro.md
@@ -25,7 +25,7 @@ The Payment Intents API allows you to initialize payment intents for no-show pol
       "email": "john.doe@example.com",
       "phone": "+1234567890",
       "party_size": 4,
-      "time": "2025-01-15T19:30:00Z",
+      "time": "2025-01-15T19:30:00",
       "locale": "en"
     },
     "created-at": "2025-01-10T12:00:00.000Z"

--- a/source/includes/restaurants/_availabilities.md
+++ b/source/includes/restaurants/_availabilities.md
@@ -161,7 +161,7 @@ it includes additional details based on the type of payment.
 When both offers and no-show policies exist for a time slot, the following priority order applies:
 
 1. **Non-optional offers** (with available tables) → Returns `TICKETING` payment type (overrides no-show policies)
-2. **Optional offers + no-show policy** → Returns `NO_SHOW` payment type (policy takes precedence)
+2. **Optional offers + no-show policy** → Returns `TICKETING` payment type (overrides no-show policies)
 3. **Optional offers + no policy** → Returns `TICKETING` payment type
 4. **No offer + no-show policy** → Returns `NO_SHOW` payment type
 5. **No offer + no policy** → Returns `false`


### PR DESCRIPTION
## Summary

Documentation updates for the async classifications support ([LIB-15478](https://libroreserve.atlassian.net/browse/LIB-15478)) and sync flow optional offer decline ([LIB-15697](https://libroreserve.atlassian.net/browse/LIB-15697)).

### Changes

- **Seatings priority logic** (`_availabilities.md`): `Optional offer + no-show policy` now returns `TICKETING` instead of `NO_SHOW`. Offer always takes precedence; the no-show deposit is the internal fallback.
- **Flows status table** (`_flows.md`): async `TICKETING` flow marked as `✓ Implemented` (previously `🚧 Work in Progress`).
- Removed the inline "Work In Progress" note on the async TICKETING link step.
- Fixed the Payment Intent time, now its treated as restaurant-local time (same way as the seatings endpoint).

The sync decline-offer / resume-offer endpoints themselves are public (portal-facing), not partner-facing, so they don't need partner API documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LIB-15478]: https://libroreserve.atlassian.net/browse/LIB-15478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIB-15697]: https://libroreserve.atlassian.net/browse/LIB-15697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ